### PR TITLE
Add missing break to grading.py

### DIFF
--- a/grading.py
+++ b/grading.py
@@ -38,6 +38,7 @@ for f in os.listdir(tests):
                     # check the number of lines in output
                     if len(out) < out_index + 1:
                         result = False
+                        break
                     # check if all the outputs are identical
                     if prev is not None and prev != out[out_index]:
                         result = False


### PR DESCRIPTION
If `len(out) < out_index + 1` then `out_index` is not a valid index of `out`, and we should break so that we don't try to evaluate `out[out_index]`.